### PR TITLE
Add support for exising AWS SSH keypairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,17 +65,18 @@ module "kubernetes_cluster_operations" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| azs | Availability Zones for the cluster (1 master per AZ will be deployed, only odd numbers are supported) | string | - | yes |
-| cluster_name_prefix | Your name of the cluster (without domain which is k8s.local by default) | string | - | yes |
-| disable_natgw | Don't use NAT Gateway for egress traffic (may be needed on some accounts) | string | `false` | no |
-| http_proxy | IP[:PORT] - address and optional port of HTTP proxy to be used to download packages | string | `` | no |
-| iam_cross_account_role_arn | Cross-account role to assume when deploying the cluster (on another account) | string | `` | no |
-| master_instance_type | Instance type (size) for master nodes | string | `m4.large` | no |
-| masters_iam_policies_arns | List of existing IAM policies that will be attached to instance profile for master nodes (EC2 instances) | list | - | yes |
-| node_count | Number of worker nodes | string | `1` | no |
-| node_instance_type | Instance type (size) for worker nodes | string | `m4.large` | no |
-| nodes_iam_policies_arns | List of existing IAM policies that will be attached to instance profile for worker nodes (EC2 instances) | list | - | yes |
-| region | AWS region | string | - | yes |
-| subnets | List of private subnets (matching AZs) where to deploy the cluster) | string | - | yes |
-| vpc_id | ID of VPC where cluster will be deployed | string | - | yes |
+| aws\_ssh\_keypair\_name | Optional name of existing SSH keypair on AWS account, to be used for cluster instances (will be generated if not specified) | string | `""` | no |
+| azs | Availability Zones for the cluster (1 master per AZ will be deployed, only odd numbers are supported) | string | n/a | yes |
+| cluster\_name\_prefix | Your name of the cluster (without domain which is k8s.local by default) | string | n/a | yes |
+| disable\_natgw | Don't use NAT Gateway for egress traffic (may be needed on some accounts) | string | `"false"` | no |
+| http\_proxy | IP[:PORT] - address and optional port of HTTP proxy to be used to download packages | string | `""` | no |
+| iam\_cross\_account\_role\_arn | Cross-account role to assume when deploying the cluster (on another account) | string | `""` | no |
+| master\_instance\_type | Instance type (size) for master nodes | string | `"m4.large"` | no |
+| masters\_iam\_policies\_arns | List of existing IAM policies that will be attached to instance profile for master nodes (EC2 instances) | list | n/a | yes |
+| node\_count | Number of worker nodes | string | `"1"` | no |
+| node\_instance\_type | Instance type (size) for worker nodes | string | `"m4.large"` | no |
+| nodes\_iam\_policies\_arns | List of existing IAM policies that will be attached to instance profile for worker nodes (EC2 instances) | list | n/a | yes |
+| region | AWS region | string | n/a | yes |
+| subnets | List of private subnets (matching AZs) where to deploy the cluster) | string | n/a | yes |
+| vpc\_id | ID of VPC where cluster will be deployed | string | n/a | yes |
 

--- a/local-exec/kentrikos_k8s_cluster_deploy.sh
+++ b/local-exec/kentrikos_k8s_cluster_deploy.sh
@@ -259,12 +259,13 @@ aws s3api put-bucket-versioning --bucket ${KOPS_BUCKET_NAME} --versioning-config
 
 
 # CREATE SSH KEY TO ACCESS K8S INSTANCES (OPTIONALLY):
-if [ -z "${AWS_SSH_KEYPAIR_NAME}" ]; then
+# FIXME: conditional statement disabled due to: https://github.com/kubernetes/kops/issues/4728
+#if [ -z "${AWS_SSH_KEYPAIR_NAME}" ]; then
     [[ ! -f ~/.ssh/id_rsa_${CLUSTER_NAME_PREFIX} ]] && ssh-keygen -N '' -f ~/.ssh/id_rsa_${CLUSTER_NAME_PREFIX}
     OPTION_SSH_PUBLIC_KEY="--ssh-public-key ~/.ssh/id_rsa_${CLUSTER_NAME_PREFIX}.pub"
-else
-    OPTION_SSH_PUBLIC_KEY=""
-fi
+#else
+#    OPTION_SSH_PUBLIC_KEY=""
+#fi
 
 
 # RUN KOPS BUT GENERATE CONFIGS ONLY:
@@ -329,9 +330,10 @@ do
     kops create -f ${JSON_FILE_OUTPUT} ${CLUSTER_NAME_PREFIX}.${CLUSTER_NAME_POSTFIX}
 done
 ## Secrets:
-if [ -z "${AWS_SSH_KEYPAIR_NAME}" ]; then
+# FIXME: conditional statement disabled due to: https://github.com/kubernetes/kops/issues/4728
+#if [ -z "${AWS_SSH_KEYPAIR_NAME}" ]; then
   kops create secret --name ${CLUSTER_NAME_PREFIX}.${CLUSTER_NAME_POSTFIX} sshpublickey admin -i ~/.ssh/id_rsa_${CLUSTER_NAME_PREFIX}.pub
-fi
+#fi
 
 
 # PRINT OUT SUMMARY:

--- a/local-exec/kentrikos_k8s_cluster_deploy.sh
+++ b/local-exec/kentrikos_k8s_cluster_deploy.sh
@@ -291,7 +291,7 @@ ${OPTION_SSH_PUBLIC_KEY} \
 ## Cluster:
 CLUSTER_JQ_FILTER=".[0] | .spec.api.loadBalancer.type = \"Internal\" | .spec.subnets = ${KOPS_SUBNETS_JSON} | .spec.docker.logDriver=\"awslogs\" | .spec.docker.logOpt=[\"awslogs-region=${REGION}\", \"awslogs-group=${CLUSTER_NAME_PREFIX}.${CLUSTER_NAME_POSTFIX}\"]"
 if [ -n "${AWS_SSH_KEYPAIR_NAME}" ]; then
-  CLUSTER_JQ_FILTER="${CLUSTER_JQ_FILTER} | spec.sshKeyName=\"${AWS_SSH_KEYPAIR_NAME}\""
+  CLUSTER_JQ_FILTER="${CLUSTER_JQ_FILTER} | .spec.sshKeyName=\"${AWS_SSH_KEYPAIR_NAME}\""
 fi
 if [ -n "${HTTP_PROXY_PARAM}" ]; then
     echo "* Including HTTP proxy configuration for: ${HTTP_PROXY_PARAM}."

--- a/local-exec/kentrikos_k8s_cluster_deploy.sh
+++ b/local-exec/kentrikos_k8s_cluster_deploy.sh
@@ -52,13 +52,14 @@ Arguments:
     -d | --node-instance-type STRING (choose instance size for worker nodes)
     -t | --masters-iam-instance-profile-arn STRING (mandatory, ARN of pre-existing instance profile for master instances)
     -b | --nodes-iam-instance-profile-arn STRING (mandatory, ARN of pre-existing instance profile for worker instances)
+    -k | --ssh-keypair-name STRING (optional, name of existing SSH keypair on AWS account, to be used for cluster instances)"
     -h | --help
 EOF
 }
 
 
 # PARSE COMMAND LINE PARAMETERS:
-OPTS=$(getopt -o c:x:r:v:z:a:s:n:p:u:l:m:d:t:b:wgh --long cluster-name-prefix:,cluster-name-postfix:,region:,vpc-id:,az:,action:,subnets:,node-count:,http-proxy:,assume-cross-account-role:,tags:,master-instance-type:,node-instance-type:,masters-iam-instance-profile-arn:,nodes-iam-instance-profile-arn:,disable-natgw,disable-subnets-tagging,help -n 'parse-options' -- "$@")
+OPTS=$(getopt -o c:x:r:v:z:a:s:n:p:u:l:m:d:t:b:k:wgh --long cluster-name-prefix:,cluster-name-postfix:,region:,vpc-id:,az:,action:,subnets:,node-count:,http-proxy:,assume-cross-account-role:,tags:,master-instance-type:,node-instance-type:,masters-iam-instance-profile-arn:,nodes-iam-instance-profile-arn:,ssh-keypair-name:,disable-natgw,disable-subnets-tagging,help -n 'parse-options' -- "$@")
 if [ $? != 0 ]; then usage; exit 1; fi
 
 eval set -- "$OPTS"
@@ -82,6 +83,7 @@ while true; do
     -n | --node-instance-type ) K8S_NODE_INSTANCE_TYPE="$2"; shift; shift ;;
     -t | --masters-iam-instance-profile-arn ) K8S_MASTERS_IAM_INSTANCE_PROFILE_ARN="$2"; shift; shift ;;
     -b | --nodes-iam-instance-profile-arn ) K8S_NODES_IAM_INSTANCE_PROFILE_ARN="$2"; shift; shift ;;
+    -k | --ssh-keypair-name ) AWS_SSH_KEYPAIR_NAME="$2"; shift; shift ;;
     -h | --help ) usage; exit 0; shift; shift ;;
     -- ) shift; break ;;
     * ) break ;;
@@ -115,6 +117,7 @@ K8S_MASTER_INSTANCE_TYPE             : $K8S_MASTER_INSTANCE_TYPE
 K8S_NODE_INSTANCE_TYPE               : $K8S_NODE_INSTANCE_TYPE
 K8S_MASTERS_IAM_INSTANCE_PROFILE_ARN : $K8S_MASTERS_IAM_INSTANCE_PROFILE_ARN
 K8S_NODES_IAM_INSTANCE_PROFILE_ARN   : $K8S_NODES_IAM_INSTANCE_PROFILE_ARN
+AWS_SSH_KEYPAIR_NAME                 : $AWS_SSH_KEYPAIR_NAME
 -----------------------------------------------------------
 EOF
 echo "ENVIRONMENT:"
@@ -255,8 +258,13 @@ aws s3 ls ${KOPS_BUCKET_NAME} || aws s3api create-bucket --bucket ${KOPS_BUCKET_
 aws s3api put-bucket-versioning --bucket ${KOPS_BUCKET_NAME} --versioning-configuration Status=Enabled
 
 
-# CREATE SSH KEY TO ACCESS K8S INSTANCES:
-[[ ! -f ~/.ssh/id_rsa_${CLUSTER_NAME_PREFIX} ]] && ssh-keygen -N '' -f ~/.ssh/id_rsa_${CLUSTER_NAME_PREFIX}
+# CREATE SSH KEY TO ACCESS K8S INSTANCES (OPTIONALLY):
+if [ -z "${AWS_SSH_KEYPAIR_NAME}" ]; then
+    [[ ! -f ~/.ssh/id_rsa_${CLUSTER_NAME_PREFIX} ]] && ssh-keygen -N '' -f ~/.ssh/id_rsa_${CLUSTER_NAME_PREFIX}
+    OPTION_SSH_PUBLIC_KEY="--ssh-public-key ~/.ssh/id_rsa_${CLUSTER_NAME_PREFIX}.pub"
+else
+    OPTION_SSH_PUBLIC_KEY=""
+fi
 
 
 # RUN KOPS BUT GENERATE CONFIGS ONLY:
@@ -273,7 +281,7 @@ kops create cluster \
 --master-size ${K8S_MASTER_INSTANCE_TYPE} \
 --node-size ${K8S_NODE_INSTANCE_TYPE} \
 --networking calico \
---ssh-public-key ~/.ssh/id_rsa_${CLUSTER_NAME_PREFIX}.pub \
+${OPTION_SSH_PUBLIC_KEY} \
 --name ${CLUSTER_NAME_PREFIX}.${CLUSTER_NAME_POSTFIX} \
 --cloud-labels ${TAGS} \
 --dry-run --output json > ${CLUSTER_NAME_PREFIX}-kops-original.json
@@ -282,12 +290,14 @@ kops create cluster \
 # MODIFY OUTPUT FILE WITH CLUSTER SPECIFICATION:
 ## Cluster:
 CLUSTER_JQ_FILTER=".[0] | .spec.api.loadBalancer.type = \"Internal\" | .spec.subnets = ${KOPS_SUBNETS_JSON} | .spec.docker.logDriver=\"awslogs\" | .spec.docker.logOpt=[\"awslogs-region=${REGION}\", \"awslogs-group=${CLUSTER_NAME_PREFIX}.${CLUSTER_NAME_POSTFIX}\"]"
+if [ -n "${AWS_SSH_KEYPAIR_NAME}" ]; then
+  CLUSTER_JQ_FILTER="${CLUSTER_JQ_FILTER} | spec.sshKeyName=\"${AWS_SSH_KEYPAIR_NAME}\""
+fi
 if [ -n "${HTTP_PROXY_PARAM}" ]; then
     echo "* Including HTTP proxy configuration for: ${HTTP_PROXY_PARAM}."
     HTTP_PROXY_HOST=$(echo ${HTTP_PROXY_PARAM} | sed -e 's/:[0-9]\+//')
     HTTP_PROXY_PORT=$(echo ${HTTP_PROXY_PARAM} | grep -o ':[0-9]\+$' | sed -e 's/://')
     CLUSTER_JQ_FILTER="${CLUSTER_JQ_FILTER} | .spec.egressProxy.httpProxy.host = \"${HTTP_PROXY_HOST}\" | .spec.egressProxy.httpProxy.port = ${HTTP_PROXY_PORT} | .spec.egressProxy.excludes = \"${HTTP_PROXY_EXCLUDES}\""
-    #CLUSTER_JQ_FILTER="${CLUSTER_JQ_FILTER} | .spec.egressProxy.httpProxy.host = \"${HTTP_PROXY_HOST}\" | .spec.egressProxy.httpProxy.port = ${HTTP_PROXY_PORT}"
 fi
 cat ${CLUSTER_NAME_PREFIX}-kops-original.json | jq "${CLUSTER_JQ_FILTER}" > ${CLUSTER_NAME_PREFIX}-kops-modified-cluster.json
 ## InstanceGroups:
@@ -319,7 +329,9 @@ do
     kops create -f ${JSON_FILE_OUTPUT} ${CLUSTER_NAME_PREFIX}.${CLUSTER_NAME_POSTFIX}
 done
 ## Secrets:
-kops create secret --name ${CLUSTER_NAME_PREFIX}.${CLUSTER_NAME_POSTFIX} sshpublickey admin -i ~/.ssh/id_rsa_${CLUSTER_NAME_PREFIX}.pub
+if [ -z "${AWS_SSH_KEYPAIR_NAME}" ]; then
+  kops create secret --name ${CLUSTER_NAME_PREFIX}.${CLUSTER_NAME_POSTFIX} sshpublickey admin -i ~/.ssh/id_rsa_${CLUSTER_NAME_PREFIX}.pub
+fi
 
 
 # PRINT OUT SUMMARY:

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ locals {
   option_http_proxy                = "${var.http_proxy    != ""     ? "--http-proxy ${var.http_proxy}" : ""}"
   option_disable_natgw             = "${var.disable_natgw == "true" ? "--disable-natgw" : ""}"
   option_assume_cross_account_role = "${var.iam_cross_account_role_arn != "" ? "--assume-cross-account-role ${var.iam_cross_account_role_arn}" : ""}"
+  option_aws_ssh_keypair_name      = "${var.aws_ssh_keypair_name != "" ? "--ssh-keypair-name ${var.aws_ssh_keypair_name}" : ""}"
 }
 
 resource "null_resource" "kubernetes_cluster" {
@@ -81,6 +82,7 @@ resource "null_resource" "kubernetes_cluster" {
       ${local.option_assume_cross_account_role} \
       ${local.option_http_proxy} \
       ${local.option_disable_natgw}
+      ${local.option_aws_ssh_keypair_name}
 EOT
 
     working_dir = "kops"

--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,7 @@ resource "null_resource" "kubernetes_cluster" {
       --nodes-iam-instance-profile-arn ${aws_iam_instance_profile.nodes.arn} \
       ${local.option_assume_cross_account_role} \
       ${local.option_http_proxy} \
-      ${local.option_disable_natgw}
+      ${local.option_disable_natgw} \
       ${local.option_aws_ssh_keypair_name}
 EOT
 

--- a/variables.tf
+++ b/variables.tf
@@ -57,3 +57,8 @@ variable "iam_cross_account_role_arn" {
   description = "Cross-account role to assume when deploying the cluster (on another account)"
   default     = ""
 }
+
+variable "aws_ssh_keypair_name" {
+  description = "Optional name of existing SSH keypair on AWS account, to be used for cluster instances (will be generated if not specified)"
+  default     = ""
+}


### PR DESCRIPTION
This PR implements a new feature - optional parameter that allows specifying and existing, AWS SSH keypair to be used for EC2 cluster instances.
Not that there is related bug in kops (mentioned in comments) but this PR works around it.